### PR TITLE
Update to discard changes on doc.close()

### DIFF
--- a/docx2pdf/__init__.py
+++ b/docx2pdf/__init__.py
@@ -24,14 +24,14 @@ def windows(paths, keep_active):
             pdf_filepath = Path(paths["output"]) / (str(docx_filepath.stem) + ".pdf")
             doc = word.Documents.Open(str(docx_filepath))
             doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
-            doc.Close()
+            doc.Close(0)
     else:
         pbar = tqdm(total=1)
         docx_filepath = Path(paths["input"]).resolve()
         pdf_filepath = Path(paths["output"]).resolve()
         doc = word.Documents.Open(str(docx_filepath))
         doc.SaveAs(str(pdf_filepath), FileFormat=wdFormatPDF)
-        doc.Close()
+        doc.Close(0)
         pbar.update(1)
 
     if not keep_active:


### PR DESCRIPTION
In our flow, the docx's created by our design team are marked as 'Read Only' so there's a flag set that will prompt to save changes even if you don't make any.  This prevented docx2pdf from succesfully working in batch mode.   

This fix was only prompted because (I think) something changed in Word.  it used to give me the option to not save the changes and keep moving